### PR TITLE
Amazon SageMaker Studio Lab 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,31 @@ https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Cha
 
 Chapter 10: 
 https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb
+
+
+また、以下のリンクから[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)でNotebookを開くことができます (事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)が必要です)。なお、いずれかのNotebookの冒頭で 
+```Python
+%pip install torch==1.9.0 matplotlib pandas tensorboard
+``` 
+によりライブラリの追加インストールを行なってください。Studio Lab の詳細は[こちら](./README_studio-lab.md)をご覧ください。
+
+Chapter 4: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb
+
+Chapter 5: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter5.ipynb
+
+Chapter 6: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter6.ipynb
+
+Chapter 7: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter7.ipynb
+
+Chapter 8: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter8.ipynb
+
+Chapter 9: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter9.ipynb
+
+Chapter 10: 
+https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 「BERTによる自然言語処理入門: Transformersを使った実践プログラミング」
 
-[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb)
-
 こちらは、[「BERTによる自然言語処理入門: Transformersを使った実践プログラミング」、(編) ストックマーク株式会社、(著) 近江 崇宏、金田 健太郎、森長 誠 、江間見 亜利、（オーム社）](https://www.amazon.co.jp/dp/427422726X)のサポートページです。
 
 
@@ -15,53 +13,23 @@
 
 ## コード
 
-それぞれ、以下のリンクからColaboratoryでNotebookを開くことができます。
+本書は、Googleの無料の計算環境である[Colaboratory](https://colab.research.google.com/)を利用して、コードを実行することを想定していますが、AWSの無料の計算環境である[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)を利用することもできます(事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)が必要です)。Colaboratoryの基本的な使い方は本書の付録を、SageMaker Studio Labの使い方は[こちら](./README_studio-lab.md)をご覧ください。
 
-Chapter 4: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb
+以下のボタンから、それぞれの計算環境で各章のNotebookを開くことができます。
 
-Chapter 5: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter5.ipynb
-
-Chapter 6: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter6.ipynb
-
-Chapter 7: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter7.ipynb
-
-Chapter 8: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter8.ipynb
-
-Chapter 9: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter9.ipynb
-
-Chapter 10: 
-https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb
+|Chapter| Google Colaboratory | Amazon SageMaker Studio Lab |
+|:---:|:---:|:---:|
+|4| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb) |
+|5| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter5.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter5.ipynb) |
+|6| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter6.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter6.ipynb) |
+|7| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter7.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter7.ipynb) |
+|8| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter8.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter8.ipynb) |
+|9| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter9.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter9.ipynb) |
+|10| [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb) |  [![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb) |
 
 
-また、以下のリンクから[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)でNotebookを開くことができます (事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)が必要です)。なお、いずれかのNotebookの冒頭で 
+なおSageMaker Studio Labを用いる場合には、いずれかのNotebookの冒頭で 
 ```Python
 %conda install pytorch==1.9 matplotlib pandas 
 ``` 
-によりライブラリの追加インストールを行なってください。Studio Lab の詳細は[こちら](./README_studio-lab.md)をご覧ください。
-
-Chapter 4: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb
-
-Chapter 5: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter5.ipynb
-
-Chapter 6: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter6.ipynb
-
-Chapter 7: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter7.ipynb
-
-Chapter 8: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter8.ipynb
-
-Chapter 9: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter9.ipynb
-
-Chapter 10: 
-https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter10.ipynb
+によりライブラリの追加インストールを行なってください。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 「BERTによる自然言語処理入門: Transformersを使った実践プログラミング」
 
+[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb)
+
 こちらは、[「BERTによる自然言語処理入門: Transformersを使った実践プログラミング」、(編) ストックマーク株式会社、(著) 近江 崇宏、金田 健太郎、森長 誠 、江間見 亜利、（オーム社）](https://www.amazon.co.jp/dp/427422726X)のサポートページです。
 
 
@@ -39,7 +41,7 @@ https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Cha
 
 また、以下のリンクから[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)でNotebookを開くことができます (事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)が必要です)。なお、いずれかのNotebookの冒頭で 
 ```Python
-%pip install torch==1.9.0 matplotlib pandas tensorboard
+%pip install torch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。Studio Lab の詳細は[こちら](./README_studio-lab.md)をご覧ください。
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@
 
 なおSageMaker Studio Labを用いる場合には、いずれかのNotebookの冒頭で 
 ```Python
-%conda install pytorch==1.9 matplotlib pandas 
+!pip install torch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://colab.research.google.com/github/stockmarkteam/bert-book/blob/master/Cha
 
 また、以下のリンクから[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)でNotebookを開くことができます (事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)が必要です)。なお、いずれかのNotebookの冒頭で 
 ```Python
-%pip install torch==1.9 matplotlib pandas 
+%conda install pytorch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。Studio Lab の詳細は[こちら](./README_studio-lab.md)をご覧ください。
 

--- a/README_studio-lab.md
+++ b/README_studio-lab.md
@@ -9,9 +9,9 @@
 ![SageMaker Studio のランディングページ](https://docs.aws.amazon.com/sagemaker/latest/dg/images/studio-lab-landing.png)
 
 ### Amazon SageMaker Studio Labを開始する
-Studio Lab を利用開始するためには、アカウントのリクエストと作成が必要です。アカウントのリクエスト手順は、
+Studio Lab を利用開始するためには、アカウントのリクエストと作成が必要です。アカウントのリクエストはこのように行います。
 
-1. [Studio Lab のランディングページ](https://studiolab.sagemaker.aws/) を開き、
+1. [Studio Lab のランディングページ](https://studiolab.sagemaker.aws/) を開きます。
 1. "Request free account" を選択します。
 1. メールアドレスなど必要な情報を記入します。
 1. "Submit request" ボタンを押します。
@@ -49,7 +49,7 @@ Studio Lab では JupyterLab のインターフェイスを拡張した UI が�
 こちらのボタンから Studio Lab で本書の Notebook を開くことができます。"Copy to project" を押し、JupyterLab に遷移した後に "Clone Entier Repo" を選択すると、この GitHub リポジトリ全体をクローンすることができます。
 なお、いずれかのNotebookの冒頭で 
 ```Python
-%pip install torch==1.9 matplotlib pandas tensorboard
+%pip install torch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。ここで、PyTorch は Studio Lab でサポートされている 1.9 を利用しました。Studio Lab の環境とカスタマイズについてはこちらの[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-manage.html) をご覧下さい。
 

--- a/README_studio-lab.md
+++ b/README_studio-lab.md
@@ -49,7 +49,7 @@ Studio Lab では JupyterLab のインターフェイスを拡張した UI が�
 こちらのボタンから Studio Lab で本書の Notebook を開くことができます。"Copy to project" を押し、JupyterLab に遷移した後に "Clone Entier Repo" を選択すると、この GitHub リポジトリ全体をクローンすることができます。
 なお、いずれかのNotebookの冒頭で 
 ```Python
-%pip install torch==1.9 matplotlib pandas 
+%conda install pytorch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。ここで、PyTorch は Studio Lab でサポートされている 1.9 を利用しました。Studio Lab の環境とカスタマイズについてはこちらの[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-manage.html) をご覧下さい。
 

--- a/README_studio-lab.md
+++ b/README_studio-lab.md
@@ -1,0 +1,61 @@
+# 「BERTによる自然言語処理入門: Transformersを使った実践プログラミング」
+
+[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb)
+
+## Amazon SageMaker Studio Lab の使い方
+
+[Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/)は無料の機械学習環境です。事前の[メールアドレスによる登録](https://studiolab.sagemaker.aws/requestAccount)を行うと、JupyterLabの実行環境が利用可能です。
+
+![SageMaker Studio のランディングページ](https://docs.aws.amazon.com/sagemaker/latest/dg/images/studio-lab-landing.png)
+
+### Amazon SageMaker Studio Labを開始する
+Studio Lab を利用開始するためには、アカウントのリクエストと作成が必要です。アカウントのリクエスト手順は、
+
+1. [Studio Lab のランディングページ](https://studiolab.sagemaker.aws/) を開き、
+1. "Request free account" を選択します。
+1. メールアドレスなど必要な情報を記入します。
+1. "Submit request" ボタンを押します。
+1. メールアドレス確認のためのEメールを受け取ったら、案内に従って設定を完了してください。
+
+以下で Studio Lab のアカウント作成を行う前に、アカウントリクエストが承認される必要があります。リクエストは 5 営業日以内に審査されます。詳細は[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-onboard.html) をご覧ください。
+
+Studio Lab アカウントの作成は、以下の手順で行います。
+1. リクエスト承認メール内の "Create account" を押しページを開きます。
+1. Eメールアドレス、パスワード、ユーザー名を入力します。
+1. "Create account" を選択します。
+
+Studio Lab へのサインインは、
+1. [Studio Lab のランディングページ](https://studiolab.sagemaker.aws/) を開き、
+1. 右上の "Sign in" ボタンを押します。
+1. Eメールアドレス、パスワード、ユーザー名を入力します。
+1. "Sign in" を選択しプロジェクトのページを開きます。
+
+### GPUを使用する
+Studio Lab では4時間の compute time のあいだ GPU インスタンスを連続して利用することができます。なお、15 GB のストレージが割り当てられるので、ダウンロードしたデータや実行したコード、保存したファイルなどは、後のサインイン時に引き続き利用することができます。コンピュートインスタンスの詳細は[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-overview.html#studio-lab-overview-project-compute) をご覧下さい。
+1. Studio Lab にサインインしたら、このようなプロジェクトページが表示されます。
+1. "My Project" 以下の "Select compute type" から `GPU` を選択します。
+1. "Start runtime" を押します。
+1. ランタイムが開始したら "Open project" をクリックし JupyterLab 環境を開きます。
+
+![Studio Lab Project](https://docs.aws.amazon.com/sagemaker/latest/dg/images/studio-lab-overview.png)
+
+### コードを実行する
+Studio Lab では JupyterLab のインターフェイスを拡張した UI が提供されています。JupyterLab の UI になじみのない方は [The JupyterLab Interface](https://jupyterlab.readthedocs.io/en/latest/user/interface.html) のページをご覧ください。
+
+![SageMaker Studio UI](https://docs.aws.amazon.com/sagemaker/latest/dg/images/studio-lab-ui.png)
+
+[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/stockmarkteam/bert-book/blob/master/Chapter4.ipynb)
+
+こちらのボタンから Studio Lab で本書の Notebook を開くことができます。"Copy to project" を押し、JupyterLab に遷移した後に "Clone Entier Repo" を選択すると、この GitHub リポジトリ全体をクローンすることができます。
+なお、いずれかのNotebookの冒頭で 
+```Python
+%pip install torch==1.9 matplotlib pandas tensorboard
+``` 
+によりライブラリの追加インストールを行なってください。ここで、PyTorch は Studio Lab でサポートされている 1.9 を利用しました。Studio Lab の環境とカスタマイズについてはこちらの[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-manage.html) をご覧下さい。
+
+### 外部ストレージ (Amazon S3) や Amazon SageMaker Studio の利用
+Studio Lab の project に割り当てられた 15 GB のストレージを超えて利用したい場合は、[Amazon S3 に接続](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-external.html#studio-lab-use-external-s3)するか、[Amazon SageMaker Studio への移行](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-migrate.html) を検討してください。
+
+## 既知の問題
+
+コードブロック#6-18でTensorBoardが表示されません、こちらは修正予定です。

--- a/README_studio-lab.md
+++ b/README_studio-lab.md
@@ -49,7 +49,7 @@ Studio Lab では JupyterLab のインターフェイスを拡張した UI が�
 こちらのボタンから Studio Lab で本書の Notebook を開くことができます。"Copy to project" を押し、JupyterLab に遷移した後に "Clone Entier Repo" を選択すると、この GitHub リポジトリ全体をクローンすることができます。
 なお、いずれかのNotebookの冒頭で 
 ```Python
-%conda install pytorch==1.9 matplotlib pandas 
+!pip install torch==1.9 matplotlib pandas 
 ``` 
 によりライブラリの追加インストールを行なってください。ここで、PyTorch は Studio Lab でサポートされている 1.9 を利用しました。Studio Lab の環境とカスタマイズについてはこちらの[ドキュメント (英語)](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab-use-manage.html) をご覧下さい。
 


### PR DESCRIPTION
無料の JupyterLab 環境である [Amazon SageMaker Studio Lab](https://studiolab.sagemaker.aws/) への対応を追加しました。

以下が変更点です: 
- README.md への "Open Studio Lab" ボタン追加、
- README.md へのリンク追加、
- Studio Lab 自体の説明のため README_studio-lab.md の追加 (付録 B の構成を参考に記述)。